### PR TITLE
feat: Add versioned documentation deployment and integrate with test …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,58 +71,101 @@ jobs:
           echo "Generating TSDoc documentation..."
           npm run docs
           echo "Documentation generated successfully"
+          
+          # Verify that TypeDoc generated the index.html file
+          if [ ! -f "docs/index.html" ]; then
+            echo "❌ Error: TypeDoc did not generate docs/index.html"
+            exit 1
+          fi
+          echo "✅ TypeDoc documentation generated successfully in docs/ folder"
 
-      # 9. Create documentation index
-      - name: Create documentation index
+      # 9. Checkout gh-pages branch to preserve existing versions
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: gh-pages
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      # 9.1. Initialize gh-pages if it doesn't exist
+      - name: Initialize gh-pages if needed
+        if: failure()
         run: |
-          echo "Creating documentation index..."
-          cat > docs/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html lang="en">
-          <head>
-              <meta charset="UTF-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1.0">
-              <title>Mosaia Node.js SDK Documentation</title>
-              <style>
-                  body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; }
-                  .container { max-width: 800px; margin: 0 auto; }
-                  h1 { color: #333; border-bottom: 2px solid #007acc; padding-bottom: 10px; }
-                  .version { background: #f0f0f0; padding: 10px; border-radius: 5px; margin: 20px 0; }
-                  .links { margin: 20px 0; }
-                  .links a { display: inline-block; margin: 5px 10px 5px 0; padding: 10px 15px; background: #007acc; color: white; text-decoration: none; border-radius: 5px; }
-                  .links a:hover { background: #005a9e; }
-              </style>
-          </head>
-          <body>
-              <div class="container">
-                  <h1>Mosaia Node.js SDK Documentation</h1>
-                  <div class="version">
-                      <strong>Version:</strong> ${{ env.version }}
-                  </div>
-                  <p>Welcome to the Mosaia Node.js SDK documentation. This SDK provides comprehensive access to the Mosaia platform through a unified TypeScript interface.</p>
-                  <div class="links">
-                      <a href="./modules.html">API Reference</a>
-                      <a href="https://github.com/mosaia-development/mosaia-node-sdk">GitHub Repository</a>
-                      <a href="https://www.npmjs.com/package/@mosaia/mosaia-node-sdk">NPM Package</a>
-                  </div>
-                  <p>The documentation is automatically generated from the source code using TypeDoc. For the most up-to-date information, please refer to the GitHub repository.</p>
-              </div>
-          </body>
-          </html>
-          EOF
-          echo "Documentation index created successfully"
+          mkdir -p gh-pages
+          cd gh-pages
+          git init
+          git checkout -b gh-pages || true
+          echo "✅ Initialized gh-pages directory"
 
-      # 10. Deploy documentation to GitHub Pages
+      # 10. Prepare versioned documentation
+      - name: Prepare versioned documentation
+        run: |
+          VERSION=${{ env.version }}
+          echo "Preparing documentation for version: $VERSION"
+          
+          # Create versioned directory in gh-pages workspace
+          VERSION_DIR="gh-pages/v$VERSION"
+          mkdir -p "$VERSION_DIR"
+          
+          # Copy documentation files
+          cp -r docs/* "$VERSION_DIR/"
+          
+          echo "✅ Versioned documentation prepared in $VERSION_DIR/"
+
+      # 11. Generate documentation index page
+      - name: Generate documentation index
+        run: |
+          chmod +x scripts/generate-docs-index.sh
+          ./scripts/generate-docs-index.sh gh-pages
+
+      # 12. Deploy versioned documentation to GitHub Pages
+      # Note: GitHub Pages must be configured to serve from the 'gh-pages' branch
+      # Settings > Pages > Source: Deploy from a branch > Branch: gh-pages / (root)
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/tags/v*'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_dir: ./gh-pages
           publish_branch: gh-pages
-          force_orphan: true
+          keep_files: false
+          force_orphan: false
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
 
-      # 11. Publish to NPM
+      # 13. Update README with latest version link
+      - name: Checkout main branch for README update
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: main-branch
+
+      - name: Update README with latest version
+        run: |
+          VERSION=${{ env.version }}
+          echo "Updating README.md with version $VERSION"
+          
+          cd main-branch
+          
+          # Update the README.md to replace LATEST_VERSION placeholder with actual version
+          sed -i "s|vLATEST_VERSION|v$VERSION|g" README.md
+          sed -i "s|Latest version: \*\*vLATEST_VERSION\*\*|Latest version: **v$VERSION**|g" README.md
+          
+          # Check if README was modified
+          if git diff --quiet README.md; then
+            echo "No changes to README.md"
+          else
+            echo "README.md updated with version $VERSION"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add README.md
+            git commit -m "docs: Update README with latest release version v$VERSION"
+            git push origin main || echo "Failed to push README update"
+          fi
+
+      # 14. Publish to NPM
       - name: Publish to NPM
         run: npm publish --access public
         env:

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -38,7 +38,7 @@ on:
 
 permissions:
   issues: write
-  contents: read
+  contents: write
 
 jobs:
   test-and-coverage:
@@ -520,3 +520,76 @@ jobs:
               echo "💡 Coverage analysis was skipped due to test failures."
             fi
           fi
+
+      # 14. Generate TSDoc documentation for deployment
+      - name: Generate TSDoc documentation for deployment
+        if: steps.typedoc-test.outcome == 'success' && steps.test-run.outcome == 'success' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
+        run: |
+          echo "Generating TSDoc documentation for deployment..."
+          npm run docs
+          echo "Documentation generated successfully"
+          
+          # Verify that TypeDoc generated the index.html file
+          if [ ! -f "docs/index.html" ]; then
+            echo "❌ Error: TypeDoc did not generate docs/index.html"
+            exit 1
+          fi
+          echo "✅ TypeDoc documentation generated successfully in docs/ folder"
+
+      # 15. Checkout gh-pages branch to preserve existing versions
+      - name: Checkout gh-pages branch
+        if: steps.typedoc-test.outcome == 'success' && steps.test-run.outcome == 'success' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: gh-pages
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      # 15.1. Initialize gh-pages if it doesn't exist
+      - name: Initialize gh-pages if needed
+        if: steps.typedoc-test.outcome == 'success' && steps.test-run.outcome == 'success' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main') && failure()
+        run: |
+          mkdir -p gh-pages
+          cd gh-pages
+          git init
+          git checkout -b gh-pages || true
+          echo "✅ Initialized gh-pages directory"
+
+      # 16. Prepare development documentation
+      - name: Prepare development documentation
+        if: steps.typedoc-test.outcome == 'success' && steps.test-run.outcome == 'success' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
+        run: |
+          echo "Preparing development documentation..."
+          
+          # Create development directory in gh-pages workspace
+          DEV_DIR="gh-pages/development"
+          mkdir -p "$DEV_DIR"
+          
+          # Copy documentation files
+          cp -r docs/* "$DEV_DIR/"
+          
+          echo "✅ Development documentation prepared in $DEV_DIR/"
+
+      # 17. Generate documentation index page
+      - name: Generate documentation index
+        if: steps.typedoc-test.outcome == 'success' && steps.test-run.outcome == 'success' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
+        run: |
+          chmod +x scripts/generate-docs-index.sh
+          ./scripts/generate-docs-index.sh gh-pages
+
+      # 18. Deploy development documentation to GitHub Pages
+      # Note: GitHub Pages must be configured to serve from the 'gh-pages' branch
+      # Settings > Pages > Source: Deploy from a branch > Branch: gh-pages / (root)
+      - name: Deploy to GitHub Pages
+        if: steps.typedoc-test.outcome == 'success' && steps.test-run.outcome == 'success' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./gh-pages
+          publish_branch: gh-pages
+          keep_files: false
+          force_orphan: false
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ const oauth = mosaia.oauth({
 
 ### Online Documentation
 
-📚 **Live Documentation**: [View the latest API documentation](https://mosaia-development.github.io/mosaia-node-sdk/)
+📚 **Latest Release**: [View the latest release documentation](https://mosaia-development.github.io/mosaia-node-sdk/vLATEST_VERSION/) | [Browse all versions](https://mosaia-development.github.io/mosaia-node-sdk/) | [Development (Latest)](https://mosaia-development.github.io/mosaia-node-sdk/development/)
+
+> **Note**: Latest version: **vLATEST_VERSION**. The link is automatically updated on each release.
 
 The documentation is automatically generated and deployed on every version release, providing:
 - **Complete API Reference**: All classes, methods, and types with detailed descriptions

--- a/scripts/generate-docs-index.sh
+++ b/scripts/generate-docs-index.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# Generate documentation index page
+# Usage: ./generate-index.sh <gh-pages-dir>
+
+set -e
+
+GH_PAGES_DIR="${1:-gh-pages}"
+
+if [ ! -d "$GH_PAGES_DIR" ]; then
+    echo "Error: Directory $GH_PAGES_DIR does not exist"
+    exit 1
+fi
+
+cd "$GH_PAGES_DIR"
+
+cat > index.html << 'INDEX_EOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mosaia Node.js SDK Documentation</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 40px 20px;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+            padding: 40px;
+        }
+        h1 {
+            color: #667eea;
+            margin-bottom: 10px;
+            font-size: 2.5em;
+        }
+        .subtitle {
+            color: #666;
+            margin-bottom: 30px;
+            font-size: 1.1em;
+        }
+        .section {
+            margin: 30px 0;
+        }
+        .section h2 {
+            color: #333;
+            margin-bottom: 15px;
+            font-size: 1.5em;
+            border-bottom: 2px solid #667eea;
+            padding-bottom: 8px;
+        }
+        .version-list {
+            list-style: none;
+        }
+        .version-item {
+            margin: 10px 0;
+            padding: 15px;
+            background: #f8f9fa;
+            border-radius: 8px;
+            border-left: 4px solid #667eea;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .version-item:hover {
+            transform: translateX(5px);
+            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
+        }
+        .version-item a {
+            text-decoration: none;
+            color: #667eea;
+            font-weight: 600;
+            font-size: 1.1em;
+            display: block;
+        }
+        .version-item a:hover {
+            color: #764ba2;
+        }
+        .version-meta {
+            color: #666;
+            font-size: 0.9em;
+            margin-top: 5px;
+        }
+        .badge {
+            display: inline-block;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 0.8em;
+            font-weight: 600;
+            margin-left: 10px;
+        }
+        .badge-latest {
+            background: #28a745;
+            color: white;
+        }
+        .badge-dev {
+            background: #ffc107;
+            color: #333;
+        }
+        .links {
+            margin-top: 30px;
+            padding-top: 30px;
+            border-top: 1px solid #e0e0e0;
+        }
+        .links a {
+            display: inline-block;
+            margin: 5px 10px 5px 0;
+            padding: 10px 20px;
+            background: #667eea;
+            color: white;
+            text-decoration: none;
+            border-radius: 6px;
+            transition: background 0.2s;
+        }
+        .links a:hover {
+            background: #764ba2;
+        }
+        .footer {
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e0e0e0;
+            color: #666;
+            font-size: 0.9em;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Mosaia Node.js SDK</h1>
+        <p class="subtitle">TypeScript SDK Documentation</p>
+        
+        <div class="section">
+            <h2>📚 Available Versions</h2>
+            <ul class="version-list">
+                <li class="version-item">
+                    <a href="./development/">Development (Latest)</a>
+                    <span class="version-meta">Latest development build - may be unstable</span>
+                    <span class="badge badge-dev">DEV</span>
+                </li>
+INDEX_EOF
+
+# Find all version directories and add them to the list (sorted by version)
+# Sort versions numerically (handles semantic versioning)
+for dir in $(ls -d v*/ 2>/dev/null | sed 's|/$||' | sort -V -r); do
+    if [ -d "$dir" ]; then
+        ver=$(basename "$dir" | sed 's/^v//')
+        echo "                <li class=\"version-item\">" >> index.html
+        echo "                    <a href=\"./$dir/\">Version $ver</a>" >> index.html
+        echo "                    <span class=\"version-meta\">Stable release</span>" >> index.html
+        echo "                    <span class=\"badge badge-latest\">v$ver</span>" >> index.html
+        echo "                </li>" >> index.html
+    fi
+done
+
+cat >> index.html << 'INDEX_EOF'
+            </ul>
+        </div>
+        
+        <div class="links">
+            <a href="https://github.com/mosaia-development/mosaia-node-sdk">GitHub Repository</a>
+            <a href="https://www.npmjs.com/package/@mosaia/mosaia-node-sdk">NPM Package</a>
+        </div>
+        
+        <div class="footer">
+            <p>Documentation is automatically generated from source code using TypeDoc.</p>
+            <p>Select a version above to view its documentation.</p>
+        </div>
+    </div>
+</body>
+</html>
+INDEX_EOF
+
+echo "✅ Index page generated in $GH_PAGES_DIR/index.html"


### PR DESCRIPTION
…workflow

- Add versioned documentation deployment for release tags (v*)
- Integrate development docs deployment into test-on-push workflow
- Add scripts for generating documentation index page
- Update README with latest release documentation link
- Automatically update README with latest version on release
- Support versioned docs at /v{VERSION}/ and development at /development/