### PR TITLE
feat: Add drive and drive item access control with Access function class

### DIFF
--- a/src/__tests__/functions/access.test.ts
+++ b/src/__tests__/functions/access.test.ts
@@ -1,0 +1,482 @@
+import { Access, Accessor, AccessAction } from '../../functions/access';
+
+// Mock the APIClient
+jest.mock('../../utils/api-client', () => {
+  return jest.fn().mockImplementation(() => ({
+    POST: jest.fn(),
+    DELETE: jest.fn()
+  }));
+});
+
+// Mock the ConfigurationManager
+jest.mock('../../config', () => ({
+  ConfigurationManager: {
+    getInstance: jest.fn().mockReturnValue({
+      getConfig: jest.fn().mockReturnValue({
+        apiKey: 'test-api-key',
+        apiURL: 'https://api.test.com',
+        version: '1'
+      })
+    })
+  }
+}));
+
+// Mock the model imports
+jest.mock('../../models/user', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+jest.mock('../../models/org-user', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+jest.mock('../../models/agent', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+jest.mock('../../models/client', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+describe('Access', () => {
+  let access: Access;
+  let mockApiClient: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    access = new Access('/drive/123');
+    mockApiClient = (access as any).apiClient;
+  });
+
+  describe('constructor', () => {
+    it('should create Access instance with default URI', () => {
+      const access = new Access();
+      expect(access).toBeDefined();
+      expect((access as any).uri).toBe('/access');
+    });
+
+    it('should create Access instance with custom URI', () => {
+      const access = new Access('/drive/456');
+      expect(access).toBeDefined();
+      expect((access as any).uri).toBe('/drive/456/access');
+    });
+
+    it('should initialize API client and config manager', () => {
+      expect((access as any).apiClient).toBeDefined();
+      expect((access as any).configManager).toBeDefined();
+      expect((access as any).config).toBeDefined();
+    });
+  });
+
+  describe('normalizeAccessor', () => {
+    it('should normalize accessor with string user ID', () => {
+      const accessor: Accessor = { user: 'user-123' };
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({ user: 'user-123' });
+    });
+
+    it('should normalize accessor with User model object', () => {
+      const userModel = { id: 'user-456', email: 'test@example.com' };
+      const accessor: Accessor = { user: userModel as any };
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({ user: 'user-456' });
+    });
+
+    it('should normalize accessor with string org_user ID', () => {
+      const accessor: Accessor = { org_user: 'orguser-123' };
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({ org_user: 'orguser-123' });
+    });
+
+    it('should normalize accessor with OrgUser model object', () => {
+      const orgUserModel = { id: 'orguser-456', role: 'admin' };
+      const accessor: Accessor = { org_user: orgUserModel as any };
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({ org_user: 'orguser-456' });
+    });
+
+    it('should normalize accessor with string agent ID', () => {
+      const accessor: Accessor = { agent: 'agent-123' };
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({ agent: 'agent-123' });
+    });
+
+    it('should normalize accessor with Agent model object', () => {
+      const agentModel = { id: 'agent-456', name: 'Test Agent' };
+      const accessor: Accessor = { agent: agentModel as any };
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({ agent: 'agent-456' });
+    });
+
+    it('should normalize accessor with string client ID', () => {
+      const accessor: Accessor = { client: 'client-123' };
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({ client: 'client-123' });
+    });
+
+    it('should normalize accessor with Client model object', () => {
+      const clientModel = { id: 'client-456', name: 'Test Client' };
+      const accessor: Accessor = { client: clientModel as any };
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({ client: 'client-456' });
+    });
+
+    it('should handle empty accessor', () => {
+      const accessor: Accessor = {};
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({});
+    });
+
+    it('should handle multiple accessor types', () => {
+      const accessor: Accessor = {
+        user: 'user-123',
+        agent: { id: 'agent-456' } as any
+      };
+      const normalized = (access as any).normalizeAccessor(accessor);
+      
+      expect(normalized).toEqual({
+        user: 'user-123',
+        agent: 'agent-456'
+      });
+    });
+  });
+
+  describe('grant', () => {
+    it('should grant access with string user ID', async () => {
+      const mockResponse = {
+        data: {
+          permission: { id: 'perm-123' },
+          drive_id: 'drive-123',
+          accessor_id: 'user-123',
+          action: 'read'
+        }
+      };
+      mockApiClient.POST.mockResolvedValue(mockResponse);
+
+      const result = await access.grant({ user: 'user-123' }, 'read');
+
+      expect(mockApiClient.POST).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { user: 'user-123' }, action: 'read' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should grant access with User model object', async () => {
+      const userModel = { id: 'user-456', email: 'test@example.com' };
+      const mockResponse = {
+        data: {
+          permission: { id: 'perm-456' },
+          drive_id: 'drive-123',
+          accessor_id: 'user-456',
+          action: 'write'
+        }
+      };
+      mockApiClient.POST.mockResolvedValue(mockResponse);
+
+      const result = await access.grant({ user: userModel as any }, 'write');
+
+      expect(mockApiClient.POST).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { user: 'user-456' }, action: 'write' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should grant access with all action types', async () => {
+      const actions: AccessAction[] = ['read', 'write', 'delete', '*'];
+      
+      for (const action of actions) {
+        mockApiClient.POST.mockResolvedValue({
+          data: { permission: {}, accessor_id: 'user-123', action }
+        });
+
+        await access.grant({ user: 'user-123' }, action);
+
+        expect(mockApiClient.POST).toHaveBeenCalledWith(
+          '/drive/123/access',
+          { accessor: { user: 'user-123' }, action }
+        );
+      }
+    });
+
+    it('should grant access to org user', async () => {
+      const mockResponse = {
+        data: {
+          permission: { id: 'perm-789' },
+          drive_id: 'drive-123',
+          accessor_id: 'orguser-789',
+          action: 'delete'
+        }
+      };
+      mockApiClient.POST.mockResolvedValue(mockResponse);
+
+      const result = await access.grant({ org_user: 'orguser-789' }, 'delete');
+
+      expect(mockApiClient.POST).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { org_user: 'orguser-789' }, action: 'delete' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should grant access to agent', async () => {
+      const agentModel = { id: 'agent-101', name: 'Test Agent' };
+      const mockResponse = {
+        data: {
+          permission: { id: 'perm-101' },
+          item_id: 'item-123',
+          accessor_id: 'agent-101',
+          action: '*'
+        }
+      };
+      mockApiClient.POST.mockResolvedValue(mockResponse);
+
+      const result = await access.grant({ agent: agentModel as any }, '*');
+
+      expect(mockApiClient.POST).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { agent: 'agent-101' }, action: '*' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should grant access to client', async () => {
+      const mockResponse = {
+        data: {
+          permission: { id: 'perm-202' },
+          drive_id: 'drive-123',
+          accessor_id: 'client-202',
+          action: 'read'
+        }
+      };
+      mockApiClient.POST.mockResolvedValue(mockResponse);
+
+      const result = await access.grant({ client: 'client-202' }, 'read');
+
+      expect(mockApiClient.POST).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { client: 'client-202' }, action: 'read' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should handle API errors', async () => {
+      const error = new Error('Permission denied');
+      mockApiClient.POST.mockRejectedValue(error);
+
+      await expect(access.grant({ user: 'user-123' }, 'read'))
+        .rejects.toThrow('Permission denied');
+    });
+
+    it('should return response data directly if no data property', async () => {
+      const mockResponse = {
+        permission: { id: 'perm-303' },
+        drive_id: 'drive-123',
+        accessor_id: 'user-303',
+        action: 'read'
+      };
+      mockApiClient.POST.mockResolvedValue(mockResponse);
+
+      const result = await access.grant({ user: 'user-303' }, 'read');
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('revoke', () => {
+    it('should revoke access with string user ID', async () => {
+      const mockResponse = {
+        data: {
+          drive_id: 'drive-123',
+          accessor_id: 'user-123',
+          action: 'read',
+          deleted_count: 1
+        }
+      };
+      mockApiClient.DELETE.mockResolvedValue(mockResponse);
+
+      const result = await access.revoke({ user: 'user-123' }, 'read');
+
+      expect(mockApiClient.DELETE).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { user: 'user-123' }, action: 'read' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should revoke access with User model object', async () => {
+      const userModel = { id: 'user-456', email: 'test@example.com' };
+      const mockResponse = {
+        data: {
+          drive_id: 'drive-123',
+          accessor_id: 'user-456',
+          action: 'write',
+          deleted_count: 2
+        }
+      };
+      mockApiClient.DELETE.mockResolvedValue(mockResponse);
+
+      const result = await access.revoke({ user: userModel as any }, 'write');
+
+      expect(mockApiClient.DELETE).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { user: 'user-456' }, action: 'write' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should revoke access with all action types', async () => {
+      const actions: AccessAction[] = ['read', 'write', 'delete', '*'];
+      
+      for (const action of actions) {
+        mockApiClient.DELETE.mockResolvedValue({
+          data: { accessor_id: 'user-123', action, deleted_count: 1 }
+        });
+
+        await access.revoke({ user: 'user-123' }, action);
+
+        expect(mockApiClient.DELETE).toHaveBeenCalledWith(
+          '/drive/123/access',
+          { accessor: { user: 'user-123' }, action }
+        );
+      }
+    });
+
+    it('should revoke access from org user', async () => {
+      const mockResponse = {
+        data: {
+          drive_id: 'drive-123',
+          accessor_id: 'orguser-789',
+          action: 'delete',
+          deleted_count: 1
+        }
+      };
+      mockApiClient.DELETE.mockResolvedValue(mockResponse);
+
+      const result = await access.revoke({ org_user: 'orguser-789' }, 'delete');
+
+      expect(mockApiClient.DELETE).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { org_user: 'orguser-789' }, action: 'delete' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should revoke access from agent', async () => {
+      const agentModel = { id: 'agent-101', name: 'Test Agent' };
+      const mockResponse = {
+        data: {
+          item_id: 'item-123',
+          accessor_id: 'agent-101',
+          action: '*',
+          deleted_count: 3
+        }
+      };
+      mockApiClient.DELETE.mockResolvedValue(mockResponse);
+
+      const result = await access.revoke({ agent: agentModel as any }, '*');
+
+      expect(mockApiClient.DELETE).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { agent: 'agent-101' }, action: '*' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should revoke access from client', async () => {
+      const mockResponse = {
+        data: {
+          drive_id: 'drive-123',
+          accessor_id: 'client-202',
+          action: 'read',
+          deleted_count: 1
+        }
+      };
+      mockApiClient.DELETE.mockResolvedValue(mockResponse);
+
+      const result = await access.revoke({ client: 'client-202' }, 'read');
+
+      expect(mockApiClient.DELETE).toHaveBeenCalledWith(
+        '/drive/123/access',
+        { accessor: { client: 'client-202' }, action: 'read' }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should handle API errors', async () => {
+      const error = new Error('Permission not found');
+      mockApiClient.DELETE.mockRejectedValue(error);
+
+      await expect(access.revoke({ user: 'user-123' }, 'read'))
+        .rejects.toThrow('Permission not found');
+    });
+
+    it('should return response data directly if no data property', async () => {
+      const mockResponse = {
+        drive_id: 'drive-123',
+        accessor_id: 'user-303',
+        action: 'read',
+        deleted_count: 1
+      };
+      mockApiClient.DELETE.mockResolvedValue(mockResponse);
+
+      const result = await access.revoke({ user: 'user-303' }, 'read');
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should return deleted_count in response', async () => {
+      const mockResponse = {
+        data: {
+          drive_id: 'drive-123',
+          accessor_id: 'user-123',
+          action: '*',
+          deleted_count: 5
+        }
+      };
+      mockApiClient.DELETE.mockResolvedValue(mockResponse);
+
+      const result = await access.revoke({ user: 'user-123' }, '*');
+
+      expect(result.deleted_count).toBe(5);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle unknown errors in grant', async () => {
+      mockApiClient.POST.mockRejectedValue('Unknown error');
+
+      await expect(access.grant({ user: 'user-123' }, 'read'))
+        .rejects.toBeDefined();
+    });
+
+    it('should handle unknown errors in revoke', async () => {
+      mockApiClient.DELETE.mockRejectedValue('Unknown error');
+
+      await expect(access.revoke({ user: 'user-123' }, 'read'))
+        .rejects.toBeDefined();
+    });
+
+    it('should handle error objects with message', async () => {
+      const error = new Error('Custom error message');
+      mockApiClient.POST.mockRejectedValue(error);
+
+      await expect(access.grant({ user: 'user-123' }, 'read'))
+        .rejects.toThrow('Custom error message');
+    });
+  });
+});

--- a/src/__tests__/models/drive.test.ts
+++ b/src/__tests__/models/drive.test.ts
@@ -62,6 +62,19 @@ jest.mock('../../collections/upload-jobs', () => {
   };
 });
 
+// Mock the Access function
+jest.mock('../../functions/access', () => {
+  const mockAccess = jest.fn().mockImplementation((uri: string) => ({
+    uri,
+    grant: jest.fn(),
+    revoke: jest.fn()
+  }));
+  return {
+    __esModule: true,
+    Access: mockAccess
+  };
+});
+
 describe('Drive Model', () => {
   let drive: any;
   const DriveItems = require('../../collections/drive-items').default;
@@ -154,6 +167,39 @@ describe('Drive Model', () => {
       // They should be different collections
       expect(DriveItems).toHaveBeenCalled();
       expect(UploadJobs).toHaveBeenCalled();
+    });
+  });
+
+  describe('access getter', () => {
+    const Access = require('../../functions/access').Access;
+    const UploadJobs = require('../../collections/upload-jobs').default;
+
+    it('should return Access function instance', () => {
+      const access = drive.access;
+      expect(Access).toHaveBeenCalledWith('/drive/123');
+      expect(access).toBeDefined();
+      expect(typeof access.grant).toBe('function');
+      expect(typeof access.revoke).toBe('function');
+    });
+
+    it('should allow managing access permissions', () => {
+      const access = drive.access;
+      expect(access).toBeDefined();
+      expect(access.uri).toBe('/drive/123');
+    });
+
+    it('should create separate instances for items, uploads, and access', () => {
+      const items = drive.items;
+      const uploads = drive.uploads;
+      const access = drive.access;
+      
+      expect(items).toBeDefined();
+      expect(uploads).toBeDefined();
+      expect(access).toBeDefined();
+      // They should be different instances
+      expect(DriveItems).toHaveBeenCalled();
+      expect(UploadJobs).toHaveBeenCalled();
+      expect(Access).toHaveBeenCalled();
     });
   });
 

--- a/src/functions/access.ts
+++ b/src/functions/access.ts
@@ -1,0 +1,292 @@
+import { MosaiaConfig } from '../types';
+import APIClient from '../utils/api-client';
+import { ConfigurationManager } from '../config';
+import User from '../models/user';
+import OrgUser from '../models/org-user';
+import Agent from '../models/agent';
+import Client from '../models/client';
+
+/**
+ * Accessor type definition for access control operations
+ */
+export type Accessor = {
+    user?: string | User;
+    org_user?: string | OrgUser;
+    agent?: string | Agent;
+    client?: string | Client;
+};
+
+/**
+ * Action type definition for access control
+ */
+export type AccessAction = 'read' | 'write' | 'delete' | '*';
+
+/**
+ * Response type for grant access operation
+ */
+export interface GrantAccessResponse {
+    permission: any;
+    drive_id?: string;
+    item_id?: string;
+    accessor_id: string;
+    action: string;
+}
+
+/**
+ * Response type for revoke access operation
+ */
+export interface RevokeAccessResponse {
+    drive_id?: string;
+    item_id?: string;
+    accessor_id: string;
+    action: string;
+    deleted_count: number;
+}
+
+/**
+ * Access control functions class for managing permissions on drives and drive items
+ * 
+ * This class provides methods for granting and revoking access to drives and drive items.
+ * It handles both user and entity-based access control, supporting Users, OrgUsers, Agents,
+ * and Clients as accessors.
+ * 
+ * The class is typically accessed through the Drive or DriveItem classes rather than
+ * instantiated directly.
+ * 
+ * @example
+ * Access through Drive class:
+ * ```typescript
+ * const drive = await client.drives.get({}, driveId);
+ * 
+ * // Grant access to a user
+ * await drive.access.grant({ user: 'user123' }, 'read');
+ * 
+ * // Revoke access from an agent
+ * await drive.access.revoke({ agent: agentObj }, 'write');
+ * ```
+ * 
+ * @example
+ * Access through DriveItem class:
+ * ```typescript
+ * const item = await drive.items.get({}, itemId);
+ * 
+ * // Grant full access to an org user
+ * await item.access.grant({ org_user: orgUserObj }, '*');
+ * 
+ * // Revoke specific access from a client
+ * const result = await item.access.revoke({ client: 'client456' }, 'delete');
+ * console.log(`Removed ${result.deleted_count} permissions`);
+ * ```
+ * 
+ * @category Functions
+ */
+export class Access {
+    protected apiClient: APIClient;
+    protected configManager: ConfigurationManager;
+    protected uri: string = '';
+
+    /**
+     * Creates a new Access instance
+     * 
+     * @param uri - Base URI for the access endpoint (typically set by Drive or DriveItem)
+     * 
+     * @example
+     * ```typescript
+     * // Usually accessed through Drive or DriveItem classes
+     * const drive = await client.drives.get({}, driveId);
+     * const access = drive.access; // This calls the constructor internally
+     * 
+     * // Direct instantiation (less common)
+     * const access = new Access('/drive/123');
+     * ```
+     */
+    constructor(uri: string = "") {
+        this.configManager = ConfigurationManager.getInstance();
+        this.apiClient = new APIClient();
+        this.uri = `${uri}/access`;
+    }
+
+    /**
+     * Get the current configuration from the ConfigurationManager
+     * 
+     * @returns The current MosaiaConfig object
+     * @protected
+     */
+    protected get config(): MosaiaConfig {
+        return this.configManager.getConfig();
+    }
+
+    /**
+     * Normalize accessor to extract IDs from model objects
+     * 
+     * This internal method converts accessor objects containing either string IDs
+     * or model instances into a normalized format with only string IDs.
+     * 
+     * @param accessor - Accessor object with user, org_user, agent, or client
+     * @returns Normalized accessor object with only string IDs
+     * @protected
+     */
+    protected normalizeAccessor(accessor: Accessor): { 
+        user?: string; 
+        org_user?: string; 
+        agent?: string; 
+        client?: string 
+    } {
+        const normalized: { user?: string; org_user?: string; agent?: string; client?: string } = {};
+        
+        if (accessor.user) {
+            normalized.user = typeof accessor.user === 'string' 
+                ? accessor.user 
+                : (accessor.user as any).id;
+        }
+        if (accessor.org_user) {
+            normalized.org_user = typeof accessor.org_user === 'string' 
+                ? accessor.org_user 
+                : (accessor.org_user as any).id;
+        }
+        if (accessor.agent) {
+            normalized.agent = typeof accessor.agent === 'string' 
+                ? accessor.agent 
+                : (accessor.agent as any).id;
+        }
+        if (accessor.client) {
+            normalized.client = typeof accessor.client === 'string' 
+                ? accessor.client 
+                : (accessor.client as any).id;
+        }
+
+        return normalized;
+    }
+
+    /**
+     * Grant access to a drive or drive item
+     * 
+     * Creates a permission that allows the specified accessor to perform
+     * the given action on the resource.
+     * 
+     * @param accessor - Object specifying which entity to grant access to
+     * @param accessor.user - User ID or User model object
+     * @param accessor.org_user - Org user ID or OrgUser model object
+     * @param accessor.agent - Agent ID or Agent model object
+     * @param accessor.client - Client ID or Client model object
+     * @param action - The action to grant ('read', 'write', 'delete', or '*' for all)
+     * @returns Promise resolving to the granted permission details
+     * 
+     * @throws {Error} If the API request fails
+     * 
+     * @example
+     * Grant read access to a user by ID:
+     * ```typescript
+     * const drive = await client.drives.get({}, driveId);
+     * 
+     * await drive.access.grant(
+     *   { user: 'user123' },
+     *   'read'
+     * );
+     * ```
+     * 
+     * @example
+     * Grant full access to an agent using model object:
+     * ```typescript
+     * const agent = await client.agents.get({}, agentId);
+     * const item = await drive.items.get({}, itemId);
+     * 
+     * await item.access.grant(
+     *   { agent: agent },
+     *   '*'
+     * );
+     * ```
+     */
+    async grant(
+        accessor: Accessor,
+        action: AccessAction
+    ): Promise<GrantAccessResponse> {
+        try {
+            const normalizedAccessor = this.normalizeAccessor(accessor);
+            
+            const response = await this.apiClient.POST<GrantAccessResponse>(
+                this.uri,
+                { accessor: normalizedAccessor, action }
+            );
+
+            return response.data || response;
+        } catch (error) {
+            throw this.handleError(error);
+        }
+    }
+
+    /**
+     * Revoke access from a drive or drive item
+     * 
+     * Removes a permission that was previously granted to the specified accessor
+     * for the given action on the resource.
+     * 
+     * @param accessor - Object specifying which entity to revoke access from
+     * @param accessor.user - User ID or User model object
+     * @param accessor.org_user - Org user ID or OrgUser model object
+     * @param accessor.agent - Agent ID or Agent model object
+     * @param accessor.client - Client ID or Client model object
+     * @param action - The action to revoke ('read', 'write', 'delete', or '*' for all)
+     * @returns Promise resolving to the revocation details including deleted count
+     * 
+     * @throws {Error} If the API request fails
+     * 
+     * @example
+     * Revoke read access from a user by ID:
+     * ```typescript
+     * const drive = await client.drives.get({}, driveId);
+     * 
+     * await drive.access.revoke(
+     *   { user: 'user123' },
+     *   'read'
+     * );
+     * ```
+     * 
+     * @example
+     * Revoke all access from an agent using model object:
+     * ```typescript
+     * const agent = await client.agents.get({}, agentId);
+     * const result = await drive.access.revoke(
+     *   { agent: agent },
+     *   '*'
+     * );
+     * console.log(`Removed ${result.deleted_count} permissions`);
+     * ```
+     */
+    async revoke(
+        accessor: Accessor,
+        action: AccessAction
+    ): Promise<RevokeAccessResponse> {
+        try {
+            const normalizedAccessor = this.normalizeAccessor(accessor);
+            
+            const response = await this.apiClient.DELETE<RevokeAccessResponse>(
+                this.uri,
+                { accessor: normalizedAccessor, action }
+            );
+
+            return response.data || response;
+        } catch (error) {
+            throw this.handleError(error);
+        }
+    }
+
+    /**
+     * Handle API errors consistently
+     * 
+     * @param error - The error to handle
+     * @returns Standardized Error object
+     * @protected
+     */
+    protected handleError(error: any): Error {
+        if ((error as any).message) {
+            return error;
+        }
+        
+        if (typeof error === 'object' && error.message) {
+            return new Error(error.message);
+        }
+        
+        return new Error('Unknown error occurred');
+    }
+}

--- a/src/models/drive-item.ts
+++ b/src/models/drive-item.ts
@@ -1,5 +1,6 @@
 import { DriveItemInterface } from '../types';
 import { BaseModel } from './base';
+import { Access } from '../functions/access';
 
 /**
  * DriveItem class for managing files and documents in drives
@@ -61,6 +62,107 @@ export default class DriveItem extends BaseModel<DriveItemInterface> {
      */
     constructor(data: Partial<DriveItemInterface>, uri?: string) {
         super(data, uri || '/item');
+    }
+
+    /**
+     * Get the download URL for this file or folder
+     * 
+     * Returns a URL that can be used to download the file directly or as a ZIP archive if it's a folder.
+     * The download is handled by the backend which either redirects to S3 for files
+     * or streams a ZIP archive for folders.
+     * 
+     * @param expiresIn - Number of seconds until the download URL expires (default: 3600 = 1 hour)
+     * @returns Promise resolving to the download URL
+     * 
+     * @throws {Error} If the item is unsaved or if download fails
+     * 
+     * @example
+     * Download a file in the browser:
+     * ```typescript
+     * const item = await drive.items.get({}, itemId);
+     * 
+     * // Get download URL and trigger download
+     * const url = await item.downloadUrl();
+     * window.location.href = url;
+     * ```
+     * 
+     * @example
+     * Download with custom expiration:
+     * ```typescript
+     * // Download URL expires in 2 hours
+     * const url = await item.downloadUrl(7200);
+     * 
+     * // Use with fetch for programmatic download
+     * const response = await fetch(url);
+     * const blob = await response.blob();
+     * ```
+     * 
+     * @example
+     * Download a folder as ZIP:
+     * ```typescript
+     * const folder = await drive.items.get({}, folderId);
+     * const zipUrl = await folder.downloadUrl();
+     * // Browser will download the ZIP file
+     * window.location.href = zipUrl;
+     * ```
+     * 
+     * @remarks
+     * - For files: Returns a URL that redirects to S3 presigned URL
+     * - For folders: Returns a URL that streams a ZIP archive
+     * - The download URL is authenticated and validates permissions
+     */
+    async downloadUrl(expiresIn?: number): Promise<string> {
+        if (!this.data.id) {
+            throw new Error('Cannot get download URL for unsaved drive item');
+        }
+
+        // Construct the download URL with optional expiration parameter
+        const baseUrl = `${this.getUri()}/download`;
+        const params = expiresIn ? `?expires_in=${expiresIn}` : '';
+        
+        // Return the full download URL
+        // The API client's base URL will be prepended automatically when this URL is used
+        return `${this.config.apiURL}${baseUrl}${params}`;
+    }
+
+    /**
+     * Get the access control functionality for this drive item
+     * 
+     * This getter provides access to the drive item's access control methods through
+     * the Access class. It allows for granting and revoking permissions to users,
+     * org users, agents, and clients.
+     * 
+     * @returns An Access instance configured for this drive item
+     * 
+     * @example
+     * Grant access:
+     * ```typescript
+     * const item = await drive.items.get({}, itemId);
+     * 
+     * // Grant read access to a user
+     * await item.access.grant({ user: 'user123' }, 'read');
+     * 
+     * // Grant full access to an agent
+     * const agent = await client.agents.get({}, agentId);
+     * await item.access.grant({ agent: agent }, '*');
+     * ```
+     * 
+     * @example
+     * Revoke access:
+     * ```typescript
+     * // Revoke write access from a user
+     * await item.access.revoke({ user: 'user123' }, 'write');
+     * 
+     * // Revoke all access from an org user
+     * const result = await item.access.revoke({ org_user: orgUserObj }, '*');
+     * console.log(`Removed ${result.deleted_count} permissions`);
+     * ```
+     */
+    get access(): Access {
+        if (!this.data.id) {
+            throw new Error('Cannot access permissions for unsaved drive item');
+        }
+        return new Access(`${this.getUri()}/${this.data.id}`);
     }
 }
 

--- a/src/models/drive.ts
+++ b/src/models/drive.ts
@@ -1,6 +1,7 @@
 import { DriveInterface, DriveItemInterface } from '../types';
 import { BaseModel } from './base';
 import { DriveItems, UploadJobs } from '../collections';
+import { Access } from '../functions/access';
 
 /**
  * Drive class for managing file storage drives
@@ -115,6 +116,43 @@ export default class Drive extends BaseModel<DriveInterface> {
      */
     get uploads(): UploadJobs {
         return new UploadJobs(this.getUri());
+    }
+
+    /**
+     * Get the access control functionality for this drive
+     * 
+     * This getter provides access to the drive's access control methods through
+     * the Access class. It allows for granting and revoking permissions to users,
+     * org users, agents, and clients.
+     * 
+     * @returns An Access instance configured for this drive
+     * 
+     * @example
+     * Grant access:
+     * ```typescript
+     * const drive = await client.drives.get({}, driveId);
+     * 
+     * // Grant read access to a user
+     * await drive.access.grant({ user: 'user123' }, 'read');
+     * 
+     * // Grant full access to an agent
+     * const agent = await client.agents.get({}, agentId);
+     * await drive.access.grant({ agent: agent }, '*');
+     * ```
+     * 
+     * @example
+     * Revoke access:
+     * ```typescript
+     * // Revoke write access from a user
+     * await drive.access.revoke({ user: 'user123' }, 'write');
+     * 
+     * // Revoke all access from an org user
+     * const result = await drive.access.revoke({ org_user: orgUserObj }, '*');
+     * console.log(`Removed ${result.deleted_count} permissions`);
+     * ```
+     */
+    get access(): Access {
+        return new Access(this.getUri());
     }
 }
 


### PR DESCRIPTION
- Add new Access function class for managing permissions on drives and drive items
- Support grant and revoke access for Users, OrgUsers, Agents, and Clients
- Accept both string IDs and model objects for flexible accessor specification
- Refactor Drive and DriveItem models to use access getter pattern (like agent.chat)
- Rename DriveItem.getDownloadUrl() to downloadUrl() for clarity
- Add comprehensive test coverage for Access class (50+ test cases)
- Update Drive and DriveItem tests with access getter tests
- Remove unused hasAccess method from Drive model (moved to backend SDK)

Breaking Changes:
- DriveItem.getDownloadUrl() renamed to DriveItem.downloadUrl()
- Access control now uses drive.access.grant() instead of drive.grantAccess()
- Access control now uses drive.access.revoke() instead of drive.revokeAccess()