### PR TITLE
fix: update tests to match new API signatures

### DIFF
--- a/src/__tests__/collections/base-collection.test.ts
+++ b/src/__tests__/collections/base-collection.test.ts
@@ -215,7 +215,7 @@ describe('BaseCollection', () => {
 
       const result = await testAPI.create(entityData);
 
-      expect(mockAPIClient.POST).toHaveBeenCalledWith('/test', entityData);
+      expect(mockAPIClient.POST).toHaveBeenCalledWith('/test', entityData, undefined);
       expect(result).toBeInstanceOf(MockModel);
       expect((result as MockModel).data.name).toBe('New User');
       expect((result as MockModel).data.email).toBe('newuser@test.com');

--- a/src/__tests__/collections/drive-items.test.ts
+++ b/src/__tests__/collections/drive-items.test.ts
@@ -312,18 +312,7 @@ describe('DriveItems', () => {
     });
 
     it('should handle empty files array', async () => {
-      const mockResponse = {
-        message: 'Upload initiated',
-        files: [],
-        instructions: {}
-      };
-
-      mockAPIClient.POST.mockResolvedValue({ data: mockResponse });
-
-      const result = await driveItems.uploadFiles([]);
-
-      expect(mockAPIClient.POST).toHaveBeenCalled();
-      expect(result.uploadJobs).toHaveLength(0);
+      await expect(driveItems.uploadFiles([])).rejects.toThrow('No files provided for upload');
     });
 
     it('should create UploadJob instances with all properties', async () => {

--- a/src/__tests__/functions/access.test.ts
+++ b/src/__tests__/functions/access.test.ts
@@ -386,7 +386,7 @@ describe('Access', () => {
       const error = new Error('Invalid role');
       mockApiClient.POST.mockRejectedValue(error);
 
-      await expect(access.grantByRole({ user: 'user-123' }, 'INVALID_ROLE'))
+      await expect(access.grantByRole({ user: 'user-123' }, 'INVALID_ROLE' as any))
         .rejects.toThrow('Invalid role');
     });
   });

--- a/src/__tests__/models/base.test.ts
+++ b/src/__tests__/models/base.test.ts
@@ -203,7 +203,7 @@ describe('BaseModel', () => {
 
       await testModel.delete();
 
-      expect(mockAPIClient.DELETE).toHaveBeenCalledWith('/test/test-123');
+      expect(mockAPIClient.DELETE).toHaveBeenCalledWith('/test/test-123', undefined);
     });
 
     it('should throw error when model has no ID', async () => {

--- a/src/__tests__/models/drive-item.test.ts
+++ b/src/__tests__/models/drive-item.test.ts
@@ -57,7 +57,6 @@ describe('DriveItem Model', () => {
       id: '456',
       drive: 'drive-123',
       name: 'document.pdf',
-      name: 'document.pdf',
       path: '/documents',
       size: 1024,
       mime_type: 'application/pdf',
@@ -137,7 +136,6 @@ describe('DriveItem Model', () => {
       expect(jsonData).toEqual({
         id: '456',
         drive: 'drive-123',
-        name: 'document.pdf',
         name: 'document.pdf',
         path: '/documents',
         size: 1024,


### PR DESCRIPTION
- Fix base-collection test to expect optional params parameter in POST
- Fix base model test to expect optional params parameter in DELETE
- Fix drive-items test to expect error for empty files array
- Fix access test to use type assertion for invalid role test
- Remove duplicate name properties in drive-item test