### PR TITLE
fix: only update changed fields

### DIFF
--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -216,7 +216,7 @@ export abstract class BaseModel<T> {
      * to the API, call {@link save} after updating.
      */
     update(updates: Partial<T>): void {
-        this.data = { ...this.data, ...updates };
+        this.data = { ...updates };
         // Update instance properties
         Object.assign(this, updates);
     }


### PR DESCRIPTION
When `update()`ing before, all fields would be dumped into `data`. This would cause problems with permissions when running `save()` if certain fields could only be changed by superorg. This only adds changed fields to `data`